### PR TITLE
Connect Streamlit UI to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,14 @@ Launch the interactive dashboard with:
 ```bash
 streamlit run dashboard/streamlit_app.py
 ```
+
+## FastAPI Backend
+
+Start the scheduler API before launching the dashboard:
+
+```bash
+uvicorn src.api.scheduler_api:app --reload
+```
+
+The Streamlit app communicates with this API using the `/simulate` endpoint to
+generate schedules.


### PR DESCRIPTION
## Summary
- connect dashboard to FastAPI `/simulate` endpoint using `requests`
- allow downloading the schedule from Streamlit
- document how to start the API in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684376d6db9c8323b6f321b55fa61dc8